### PR TITLE
Add suite fallback for missing parentSuite label

### DIFF
--- a/pandas_chunking.py
+++ b/pandas_chunking.py
@@ -35,7 +35,10 @@ def chunk_json_to_jsonl(data, output_path: str, report_uuid: str) -> pd.DataFram
             "name": t.get("name"),
             "parentSuite": next(
                 (l["value"] for l in t.get("labels", []) if l.get("name") == "parentSuite"),
-                "unknown",
+                next(
+                    (l["value"] for l in t.get("labels", []) if l.get("name") == "suite"),
+                    "unknown",
+                ),
             ),
             "suite": next(
                 (l["value"] for l in t.get("labels", []) if l.get("name") == "suite"),


### PR DESCRIPTION
## Summary
- improve parentSuite detection when chunking Allure reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b34705a48331a97cbc48e95025ab