### PR TITLE
Fix team selection fallback

### DIFF
--- a/embeddings.py
+++ b/embeddings.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     logger.info("Generated embeddings: %s", embeddings.shape)
 
     first_row = df.iloc[0]
-    team = first_row["parentSuite"]
+    team = first_row.get("parentSuite") or first_row.get("suite")
     report_uuid = first_row["report_uuid"]
     path = save_embeddings(embeddings, team, report_uuid)
     logger.info("Embeddings saved to %s", path)

--- a/save_embeddings_to_qdrant.py
+++ b/save_embeddings_to_qdrant.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     df = load_chunks(CHUNKS_PATH)
     first_row = df.iloc[0]
-    team = first_row["parentSuite"]
+    team = first_row.get("parentSuite") or first_row.get("suite")
     report_uuid = first_row["report_uuid"]
 
     emb_path = os.path.join(EMBEDDINGS_DIR, team, f"{report_uuid}.npy")


### PR DESCRIPTION
## Summary
- ensure `parentSuite` fallback to `suite` when missing

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b65738148331b7565ca389f45da5