### PR TITLE
Add total test count to summary

### DIFF
--- a/report_summary.py
+++ b/report_summary.py
@@ -10,6 +10,7 @@ HTML_COLORS = {
     "failed": "red",
     "broken": "orange",
     "skipped": "gray",
+    "total": "blue",
 }
 
 
@@ -131,6 +132,8 @@ def format_report_summary(
     sc = info["status_counts"]
     # generate one line per status after the date line
     status_lines = [_fmt_status(s, sc[s], color) for s in STATUS_ORDER]
+    total_tests = sum(sc.values())
+    status_lines.append(_fmt_status("total", total_tests, color))
 
     lines = [f"**{date_str}**:"]
     lines.extend(status_lines)

--- a/tests/test_format_report_summary.py
+++ b/tests/test_format_report_summary.py
@@ -1,0 +1,8 @@
+import re
+from report_summary import format_report_summary
+
+
+def test_total_in_summary_blue():
+    case = {"labels": [], "status": "passed", "time": {"start": 1}}
+    summary = format_report_summary([case], color=True, fallback_timestamp=0)
+    assert re.search(r'<span style="color:blue;">total=1</span>', summary)


### PR DESCRIPTION
## Summary
- show total number of tests in report summary
- color the total in blue
- test that the summary includes the new line

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d46300108331838f8eb8c0ed3f97