### PR TITLE
Add per-request prompt analysis API

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -88,7 +88,12 @@ def chunk_and_save_json(json_data, uuid, test_suite_name):
     return output_path, df
 
 
-def analyze_and_post(uuid: str, test_suite_name: str, report_data):
+def analyze_and_post(
+    uuid: str,
+    test_suite_name: str,
+    report_data,
+    question_override: str | None = None,
+):
     """
     Выполняет RAG-анализ и отправляет результат на Allure-сервер.
 
@@ -99,7 +104,7 @@ def analyze_and_post(uuid: str, test_suite_name: str, report_data):
     """
     # 1. Генерируем анализ
     try:
-        analysis_result = run_rag_analysis(test_suite_name)
+        analysis_result = run_rag_analysis(test_suite_name, question_override)
         analysis_text = analysis_result.get("analysis", "")
     except RagAnalysisError as e:
         logger.error("RAG analysis failed for %s: %s", uuid, e)


### PR DESCRIPTION
## Summary
- allow rag_pipeline to accept a question override
- permit analyze_and_post to send a custom prompt
- add /prompt/analyze endpoint for single-use prompts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651eb278788331819f9948e19ef342