### PR TITLE
Add prompt override for one-off analysis

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,7 +164,12 @@ async def analyze_report_with_prompt(request: Request):
         raise HTTPException(status_code=500, detail=f"Не удалось загрузить эмбеддинги: {e}") from e
 
     try:
-        analyze_and_post(uuid, test_suite_name, report_data, prompt)
+        analyze_and_post(
+            uuid,
+            test_suite_name,
+            report_data,
+            prompt_override=prompt,
+        )
     except Exception as e:
         logger.error("Не удалось выполнить анализ для %s: %s", uuid, e)
         return {"Результат": "частичный", "Ошибка": f"{str(e)}\nСорян, не могу перевести ошибку на русский. Попробуй Google Translate, если языки — не твоё."}

--- a/utils.py
+++ b/utils.py
@@ -93,6 +93,7 @@ def analyze_and_post(
     test_suite_name: str,
     report_data,
     question_override: str | None = None,
+    prompt_override: str | None = None,
 ):
     """
     Выполняет RAG-анализ и отправляет результат на Allure-сервер.
@@ -104,7 +105,11 @@ def analyze_and_post(
     """
     # 1. Генерируем анализ
     try:
-        analysis_result = run_rag_analysis(test_suite_name, question_override)
+        analysis_result = run_rag_analysis(
+            test_suite_name,
+            question_override,
+            prompt_override,
+        )
         analysis_text = analysis_result.get("analysis", "")
     except RagAnalysisError as e:
         logger.error("RAG analysis failed for %s: %s", uuid, e)


### PR DESCRIPTION
## Summary
- allow overriding the full prompt when analyzing reports
- pass temporary prompt override via `/prompt/analyze`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866696010f48331b5ed184a2b3fc5bf